### PR TITLE
allow higher versions of dependencies; remove unnecessary dependencies

### DIFF
--- a/name.njbartlett.eclipse.macbadge/META-INF/MANIFEST.MF
+++ b/name.njbartlett.eclipse.macbadge/META-INF/MANIFEST.MF
@@ -5,12 +5,9 @@ Bundle-SymbolicName: name.njbartlett.eclipse.macbadge;singleton:=true
 Bundle-Version: 1.0.0.qualifier
 Bundle-RequiredExecutionEnvironment: J2SE-1.5
 Import-Package: org.eclipse.core.resources,
- org.eclipse.core.runtime;version="3.4.0",
- org.eclipse.core.runtime.preferences;version="3.3.0",
+ org.eclipse.core.runtime;version="[3.4.0,4.0.0)",
+ org.eclipse.core.runtime.preferences;version="[3.3.0,4.0.0)",
  org.eclipse.jface.preference,
- org.eclipse.swt.internal.cocoa,
  org.eclipse.ui,
- org.eclipse.ui.preferences,
- org.eclipse.ui.progress,
- org.eclipse.core.runtime.jobs
-Require-Bundle: org.eclipse.swt;bundle-version="3.7.0"
+ org.eclipse.ui.preferences
+Require-Bundle: org.eclipse.swt;bundle-version="[3.7.0,4.0.0)"


### PR DESCRIPTION
Hi,
I've just updated the versions to make it possible to use it with later eclipse versions.
Also I've removed some dependencies that seem unneeded.
Actually it seems that this might work on other platforms, too...
Thanks for this great plugin. It's so simple but extremely useful!
